### PR TITLE
Spacing issues and path fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,22 @@ Emoji support for XeLaTeX documents
 ## Installation
 Clone this repo into your [`texmf` folder](https://en.wikibooks.org/wiki/LaTeX/Installing_Extra_Packages) or to the project folder. Clone emoji images named after the utf8 code - I recommend [EmojiOne](https://github.com/Ranks/emojione).
 
-Note: Tex doesn't natively support SVG, so if you download the vector emojis, you can convert them to PDFs with the following command on Mac and Linux:
+Note: Tex doesn't natively support SVG, so if you download the vector emojis, you can convert them to PDFs with the following command on Mac and Linux: (assumes you have installed the librsvg2-bin package in Linux
 
 ```bash
-rsvg-convert -f pdf -o <emoji-UTF-code>.pdf <emoji-UTF-code>.svg
+# For Mac OS X:
+$ brew install librsvg
+
+# For Linux:
+$ sudo apt-get install librsvg2-bin
+
+# Then, run:
+$ rsvg-convert -f pdf -o <emoji-UTF-code>.pdf <emoji-UTF-code>.svg
+```
+
+If you don't want to hand convert massive emoji SVGs, run the ```svgs-to-pdfs``` command (included this repo) in the folder where the SVGs are:
+```bash
+./svgs-to-pdfs ./*.svg
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Emoji support for XeLaTeX documents
 ## Installation
 Clone this repo into your [`texmf` folder](https://en.wikibooks.org/wiki/LaTeX/Installing_Extra_Packages) or to the project folder. Clone emoji images named after the utf8 code - I recommend [EmojiOne](https://github.com/Ranks/emojione).
 
+Note: Tex doesn't natively support SVG, so if you download the vector emojis, you can convert them to PDFs with the following command on Mac and Linux:
+
+```bash
+rsvg-convert -f pdf -o <emoji-UTF-code>.pdf <emoji-UTF-code>.svg
+```
+
 ## Usage
 Use the `xelatexemoji` package. Enjoy :)
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ yields (using the great [EmojiOne](https://github.com/Ranks/emojione) images)
 By default, xelatex-emoji expects the images to be in `images/utf8code.png`. You can change the path and extension by creating your own `\xelatexemojipath` command.
 
 ```tex
-\newcommand{\xelatexemojipath}[1]{mycustompath/{#1}.pdf}
+\newcommand{\xelatexemojipath}[1]{mycustompath/#1.pdf}
 ```
 
 ## Development

--- a/svgs-to-pdfs
+++ b/svgs-to-pdfs
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+SAVEIFS=$IFS
+IFS=$(echo -en "\n\b")
+for f in $*
+do
+  filename=$(basename "$f")
+  filename="${filename%.*}"
+  if `rsvg-convert -f pdf -o "$filename.pdf" "$filename.svg"`
+  then echo "Converted $f"
+  fi
+done
+IFS=$SAVEIFS
+
+
+

--- a/xelatexemoji.sty
+++ b/xelatexemoji.sty
@@ -4,13 +4,11 @@
 \providecommand{\xelatexemojipath}[1]{images/{#1}.png}
 
 \newcommand{\xelatexemoji}[1]{
-  \text{
     \hspace{-1em}
     \raisebox{-0.15em}{
       \includegraphics[height=1em]{\xelatexemojipath{#1}}
     }
     \hspace{-1em}
-  }
 }
 
 \newunicodechar{😁}{\xelatexemoji{1f601}}

--- a/xelatexemoji.sty
+++ b/xelatexemoji.sty
@@ -1,7 +1,7 @@
 \usepackage{newunicodechar}
 \usepackage{amsmath}
 
-\providecommand{\xelatexemojipath}[1]{images/{#1}.png}
+\providecommand{\xelatexemojipath}[1]{images/#1.png}
 
 \newcommand{\xelatexemoji}[1]{%
     \raisebox{-0.15em}{%

--- a/xelatexemoji.sty
+++ b/xelatexemoji.sty
@@ -3,12 +3,10 @@
 
 \providecommand{\xelatexemojipath}[1]{images/{#1}.png}
 
-\newcommand{\xelatexemoji}[1]{
-    \hspace{-1em}
-    \raisebox{-0.15em}{
-      \includegraphics[height=1em]{\xelatexemojipath{#1}}
-    }
-    \hspace{-1em}
+\newcommand{\xelatexemoji}[1]{%
+    \raisebox{-0.15em}{%
+      \includegraphics[height=1em]{\xelatexemojipath{#1}}%
+    }%
 }
 
 \newunicodechar{😁}{\xelatexemoji{1f601}}


### PR DESCRIPTION
Extra space between emojis (which wildly resize upon switching fonts) were caused by leaving out the % after each command line. Fixed this and a path error, and updated README for help with converting SVG to PDF.
