### PR TITLE
Do Not Specify Extension of Emoji Image Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ yields (using the great [EmojiOne](https://github.com/Ranks/emojione) images)
 
 By default, xelatex-emoji expects the images to be in `images/utf8code.extension`. The package supports the same image formats (extensions) as XeLaTeX.
 
-For example: If you insert the emoji 💩 (code `1F4A9`) in your document, then the translation will work if the file `images/1F4A9.pdf` or `images/1F4A9.png` exist. If both exist, then XeLaTeX will use the “better” version `images/1F4A9.pdf`.
+For example: If you insert the emoji 👌 (code `1F44C`) in your document, then the translation will work if the file `images/1F44C.pdf` or `images/1F44C.png` exist. If both exist, then XeLaTeX will use the “better” version `images/1F44C.pdf`.
 
 You can change the emoji image path and extension by creating your own `\xelatexemojipath` command.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ yields (using the great [EmojiOne](https://github.com/Ranks/emojione) images)
 
 ### Image path
 
-By default, xelatex-emoji expects the images to be in `images/utf8code.png`. You can change the path and extension by creating your own `\xelatexemojipath` command.
+By default, xelatex-emoji expects the images to be in `images/utf8code.extension`. The package supports the same image formats (extensions) as XeLaTeX.
+
+For example: If you insert the emoji 💩 (code `1F4A9`) in your document, then the translation will work if the file `images/1F4A9.pdf` or `images/1F4A9.png` exist. If both exist, then XeLaTeX will use the “better” version `images/1F4A9.pdf`.
+
+You can change the emoji image path and extension by creating your own `\xelatexemojipath` command.
 
 ```tex
 \newcommand{\xelatexemojipath}[1]{mycustompath/#1.pdf}

--- a/xelatexemoji.sty
+++ b/xelatexemoji.sty
@@ -1,7 +1,7 @@
 \usepackage{newunicodechar}
 \usepackage{amsmath}
 
-\providecommand{\xelatexemojipath}[1]{images/#1.png}
+\providecommand{\xelatexemojipath}[1]{images/#1}
 
 \newcommand{\xelatexemoji}[1]{%
     \raisebox{-0.15em}{%


### PR DESCRIPTION
Hi Petr,

thank you for this very useful LaTeX package. The commit below contains a small improvement concerning the way `xelatex-emoji` determines the image file for a certain emoji. If I should change anything in this pull request, then please just let me know.

Kind regards,
  René
